### PR TITLE
【Fixed】step7:タスクを登録・更新・削除できるようにする

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,0 +1,50 @@
+class TasksController < ApplicationController
+  before_action :set_task, only: [:show, :edit, :update, :destroy]
+
+  def index
+    @tasks = Task.all
+  end
+
+  def show
+  end
+
+  def new
+    @task = Task.new
+  end
+
+  def edit
+  end
+
+  def create
+    @task = Task.new(task_params)
+    if @task.save
+      redirect_to @task, notice: 'タスクを作成しました。'
+    else
+      render :new
+    end
+  end
+
+  def update
+    if @task.update(task_params)
+      redirect_to @task, notice: 'タスクを更新しました。'
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    @task.destroy
+    redirect_to tasks_url, notice: 'タスクを削除しました。'
+  end
+
+  private
+
+  def set_task
+    @task = Task.find(params[:id])
+  end
+
+  def task_params
+    params.require(:task).permit(:name, :description)
+  end
+
+end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,2 +1,5 @@
 class Task < ApplicationRecord
+
+  validates :name, length: { in: 1..150 }
+
 end

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -1,0 +1,27 @@
+<%= form_with(model: @task, local: true) do |form| %>
+  <% if task.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(task.errors.count, "件") %> のエラーが発生しました</h2>
+      <ul>
+        <% task.errors.full_messages.each do |message| %>
+          <li><%= message %></li>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :タスク名 %>
+    <%= form.text_field :name %>
+  </div>
+
+  <div class="field">
+    <%= form.label :説明 %>
+    <%= form.text_field :description %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+
+<% end %>

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -1,0 +1,8 @@
+<h1>タスク編集</h1>
+
+<%= render 'form', task: @task %>
+
+<br>
+
+<%= link_to '詳細', @task %> |
+<%= link_to '戻る', tasks_path %>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -1,0 +1,28 @@
+<p id="notice"><%= notice %></p>
+
+<h1>タスク一覧</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>タスク名</th>
+      <th>説明</th>
+      <th colspan="2"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @tasks.each do |task| %>
+      <tr>
+        <td><%= link_to task.name, task %></td>
+        <td><%= task.description %></td>
+        <td><%= link_to '編集', edit_task_path(task) %></td>
+        <td><%= link_to '削除', task, method: :delete, data: { confirm: 'このタスクを削除します。よろしいですか?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'タスクを作成する', new_task_path %>

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -1,0 +1,7 @@
+<h1>タスクの新規作成</h1>
+
+<%= render 'form', task: @task %>
+
+<br>
+
+<%= link_to '戻る', tasks_path %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,0 +1,11 @@
+<h1>タスク詳細</h1>
+
+<p id="notice"><%= notice %></p>
+
+<p>タスク名：<strong><%= @task.name %></strong></p>
+<p>　説　明：<strong><%= @task.description %></strong></p>
+
+<br>
+
+<%= link_to '編集', edit_task_path(@task) %> |
+<%= link_to '戻る', tasks_path %>

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -1,0 +1,8 @@
+ja:
+  activerecord:
+    models:
+      task: タスク
+    attributes:
+      task:
+        name: タスク名
+        description: 説明

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,9 @@
 Rails.application.routes.draw do
 
-  mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
+  root 'tasks#index'
+
+  resources :tasks
+
+  # mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
 
 end

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -1,0 +1,48 @@
+require 'test_helper'
+
+class TasksControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @task = tasks(:one)
+  end
+
+  test "should get index" do
+    get tasks_url
+    assert_response :success
+  end
+
+  test "should get new" do
+    get new_task_url
+    assert_response :success
+  end
+
+  test "should create task" do
+    assert_difference('Task.count') do
+      post tasks_url, params: { task: {  } }
+    end
+
+    assert_redirected_to task_url(Task.last)
+  end
+
+  test "should show task" do
+    get task_url(@task)
+    assert_response :success
+  end
+
+  test "should get edit" do
+    get edit_task_url(@task)
+    assert_response :success
+  end
+
+  test "should update task" do
+    patch task_url(@task), params: { task: {  } }
+    assert_redirected_to task_url(@task)
+  end
+
+  test "should destroy task" do
+    assert_difference('Task.count', -1) do
+      delete task_url(@task)
+    end
+
+    assert_redirected_to tasks_url
+  end
+end

--- a/test/system/tasks_test.rb
+++ b/test/system/tasks_test.rb
@@ -1,0 +1,41 @@
+require "application_system_test_case"
+
+class TasksTest < ApplicationSystemTestCase
+  setup do
+    @task = tasks(:one)
+  end
+
+  test "visiting the index" do
+    visit tasks_url
+    assert_selector "h1", text: "Tasks"
+  end
+
+  test "creating a Task" do
+    visit tasks_url
+    click_on "New Task"
+
+    click_on "Create Task"
+
+    assert_text "Task was successfully created"
+    click_on "Back"
+  end
+
+  test "updating a Task" do
+    visit tasks_url
+    click_on "Edit", match: :first
+
+    click_on "Update Task"
+
+    assert_text "Task was successfully updated"
+    click_on "Back"
+  end
+
+  test "destroying a Task" do
+    visit tasks_url
+    page.accept_confirm do
+      click_on "Destroy", match: :first
+    end
+
+    assert_text "Task was successfully destroyed"
+  end
+end


### PR DESCRIPTION
#5 
 [ステップ7: タスクを登録・更新・削除できるようにしよう](https://diver.diveintocode.jp/curriculums/1277#jump-7)

- [ ] タスクの一覧画面、作成画面、詳細画面、編集画面を作成する

- [ ] rails generate controller コマンドでコントローラとビューを作成する

- [ ] コントローラとビューに必要な実装を追加する

- [ ] 作成、更新、削除後はそれぞれflashメッセージを画面に表示させる

- [ ] routes.rb を編集して、 http://localhost:3000/ でタスクの一覧画面が表示されるようにする
