### PR TITLE
【Fixed】step11:タスク一覧を作成日時の順番で並び替える

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,7 +2,8 @@ class TasksController < ApplicationController
   before_action :set_task, only: [:show, :edit, :update, :destroy]
 
   def index
-    @tasks = Task.all
+    @tasks = Task.all.order(created_at: :desc)
+    # raise
   end
 
   def show

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -16,7 +16,7 @@
   <tbody>
     <% @tasks.each do |task| %>
       <tr>
-        <td><%= link_to task.name, task %></td>
+        <td><%= link_to task.name, task, class: 'task_name' %></td>
         <td><%= task.description %></td>
         <td><%= link_to t('views.tasks.edit'), edit_task_path(task) %></td>
         <td><%= link_to t('views.tasks.destroy'), task, method: :delete, data: { confirm: "このタスクを削除します。よろしいですか？" } %></td>

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,0 +1,13 @@
+FactoryBot.define do
+  factory :task_test1, class: Task do
+    name { 'テスト1:タスク名' }
+    description { 'テスト1:説明' }
+    created_at { Time.current + 1.days }
+  end
+
+  factory :task_test2, class: Task do
+    name { 'テスト2:タスク名' }
+    description { 'テスト2:説明' }
+    created_at { Time.current + 2.days }
+  end
+end

--- a/spec/features/task.spec.rb
+++ b/spec/features/task.spec.rb
@@ -1,33 +1,45 @@
 require 'rails_helper'
 
 RSpec.feature "タスク管理機能", type: :feature do
-  scenario "タスク一覧のテスト" do
-    Task.create!(name: 'test_task_name_01', description: 'test_task_description_01')
-    Task.create!(name: 'test_task_name_02', description: 'test_task_description_02')
+  background do
+    FactoryBot.create(:task_test1)
+    FactoryBot.create(:task_test2)
+  end
 
+  scenario "タスク一覧のテスト" do
     visit tasks_path
 
-    expect(page).to have_content 'test_task_name_01'
-    expect(page).to have_content 'test_task_name_02'
-
-    expect(page).to have_content 'test_task_description_01'
-    expect(page).to have_content 'test_task_description_02'
+    expect(page).to have_content 'テスト1:タスク名'
+    expect(page).to have_content 'テスト2:タスク名'
+    expect(page).to have_content 'テスト1:説明'
+    expect(page).to have_content 'テスト2:説明'
   end
 
   scenario "タスク作成のテスト" do
     visit new_task_path
 
-    fill_in 'task_name', with: 'test_task_name_03'
-    fill_in 'task_description', with: 'test_task_description_03'
+    fill_in 'task_name', with: 'テスト3:タスク名'
+    fill_in 'task_description', with: 'テスト3:説明'
 
     click_on '登録する'
 
-    expect(page).to have_content 'test_task_name_03'
+    expect(page).to have_content 'テスト3:タスク名'
+    expect(page).to have_content 'テスト3:説明'
   end
 
   scenario "タスク詳細のテスト" do
-    Task.create!(id: 4, name: 'test_task_name_04', description: 'test_task_description_04')
+    visit task_path(1)
+    visit task_path(2)
+  end
 
-    visit task_path(4)
+  scenario "タスクが作成日時の降順に並んでいるかのテスト" do
+    visit tasks_path
+
+    task = all('.task_name')
+    task_first = task.first
+    task_last = task.last
+
+    expect(task_first).to have_content "テスト2:タスク名"
+    expect(task_last).to have_content "テスト1:タスク名"
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -20,7 +20,7 @@ require 'rspec/rails'
 # directory. Alternatively, in the individual `*_spec.rb` files, manually
 # require only the support files necessary.
 #
-# Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.
@@ -71,4 +71,6 @@ RSpec.configure do |config|
   config.after(:all) do
     DatabaseCleaner.clean
   end
+
+  config.include FactoryBot::Syntax::Methods
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -93,4 +93,7 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 =end
+  config.before(:all) do
+    FactoryBot.reload
+  end
 end


### PR DESCRIPTION
#13 
[ステップ11: タスク一覧を作成日時の順番で並び替えよう](https://diver.diveintocode.jp/curriculums/1277#jump-11)

- [ ] 現在IDの順で並んでいるが、これを作成日時の降順で並び替える

- [ ] 並び替えがうまく行っていることをfeature specで書いてみる