### PR TITLE
【Fixed】step14:終了期限を追加する

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,8 +2,11 @@ class TasksController < ApplicationController
   before_action :set_task, only: [:show, :edit, :update, :destroy]
 
   def index
-    @tasks = Task.all.order(created_at: :desc)
-    # raise
+    if params[:sort_expired] == "deadline"
+      @tasks = Task.all.order(:deadline)
+    else
+      @tasks = Task.all.order(created_at: :desc)
+    end
   end
 
   def show
@@ -45,7 +48,7 @@ class TasksController < ApplicationController
   end
 
   def task_params
-    params.require(:task).permit(:name, :description)
+    params.require(:task).permit(:name, :description, :deadline)
   end
 
 end

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -20,6 +20,11 @@
     <%= form.text_field :description %>
   </div>
 
+  <div class="field">
+    <%= form.label :deadline, id: "task_deadline"  %>
+    <%= form.datetime_field :deadline %>
+  </div>
+
   <div class="actions">
     <%= form.submit %>
   </div>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -4,11 +4,15 @@
 
 <br>
 
+<%= link_to "作成日時順", tasks_path %>
+<%= link_to "終了期限順", tasks_path(sort_expired: "deadline") %>
+
 <table>
   <thead>
     <tr>
       <th><%= t('views.tasks.name') %></th>
       <th><%= t('views.tasks.description') %></th>
+      <th>終了期限</th>
       <th colspan="2"></th>
     </tr>
   </thead>
@@ -18,6 +22,7 @@
       <tr>
         <td><%= link_to task.name, task, class: 'task_name' %></td>
         <td><%= task.description %></td>
+        <td><%= task.deadline %></td>
         <td><%= link_to t('views.tasks.edit'), edit_task_path(task) %></td>
         <td><%= link_to t('views.tasks.destroy'), task, method: :delete, data: { confirm: "このタスクを削除します。よろしいですか？" } %></td>
       </tr>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -6,6 +6,8 @@
 
 <p><%= t('views.tasks.name') %>：<strong><%= @task.name %></strong></p>
 <p><%= t('views.tasks.description') %>：<strong><%= @task.description %></strong></p>
+<p>終了期限：<strong><%= @task.deadline %></strong></p>
+
 
 <br>
 

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -6,3 +6,4 @@ ja:
       task:
         name: タスク名
         description: 説明
+        deadline: 終了期限

--- a/config/locales/views/tasks/ja.yml
+++ b/config/locales/views/tasks/ja.yml
@@ -3,6 +3,7 @@ ja:
     tasks:
       name: タスク名
       description: 説明
+      deadline: 終了期限
       create: 新規作成
       show: 詳細
       edit: 編集

--- a/db/migrate/20190916065215_add_deadline_to_tasks.rb
+++ b/db/migrate/20190916065215_add_deadline_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddDeadlineToTasks < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tasks, :deadline, :datetime, default: -> { 'NOW()' }, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_13_074837) do
+ActiveRecord::Schema.define(version: 2019_09_16_065215) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 2019_09_13_074837) do
     t.text "description"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "deadline", default: -> { "now()" }, null: false
   end
 
 end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,13 +1,25 @@
 FactoryBot.define do
   factory :task_test1, class: Task do
-    name { 'テスト1:タスク名' }
-    description { 'テスト1:説明' }
-    created_at { Time.current + 1.days }
+    name { 'タスク名カラム1' }
+    description { '説明カラム1' }
+    created_at { Time.current }
+    updated_at { Time.current }
+    deadline { Time.current }
   end
 
   factory :task_test2, class: Task do
-    name { 'テスト2:タスク名' }
-    description { 'テスト2:説明' }
+    name { 'タスク名カラム2' }
+    description { '説明カラム2' }
+    created_at { Time.current + 1.days }
+    updated_at { Time.current + 2.days }
+    deadline { Time.current + 3.days }
+  end
+
+  factory :task_test3, class: Task do
+    name { 'タスク名カラム3' }
+    description { '説明カラム3' }
     created_at { Time.current + 2.days }
+    updated_at { Time.current + 3.days }
+    deadline { Time.current + 4.days }
   end
 end

--- a/spec/features/task.spec.rb
+++ b/spec/features/task.spec.rb
@@ -4,42 +4,63 @@ RSpec.feature "タスク管理機能", type: :feature do
   background do
     FactoryBot.create(:task_test1)
     FactoryBot.create(:task_test2)
+    FactoryBot.create(:task_test3)
   end
 
   scenario "タスク一覧のテスト" do
     visit tasks_path
 
-    expect(page).to have_content 'テスト1:タスク名'
-    expect(page).to have_content 'テスト2:タスク名'
-    expect(page).to have_content 'テスト1:説明'
-    expect(page).to have_content 'テスト2:説明'
+    expect(page).to have_content 'タスク名カラム1'
+    expect(page).to have_content '説明カラム1'
+    expect(page).to have_content Time.current
+    expect(page).to have_content 'タスク名カラム2'
+    expect(page).to have_content '説明カラム2'
+    expect(page).to have_content Time.current + 3.days
+    expect(page).to have_content 'タスク名カラム3'
+    expect(page).to have_content '説明カラム3'
+    expect(page).to have_content Time.current + 4.days
   end
 
   scenario "タスク作成のテスト" do
     visit new_task_path
 
-    fill_in 'task_name', with: 'テスト3:タスク名'
-    fill_in 'task_description', with: 'テスト3:説明'
+    fill_in 'task_name', with: 'タスク名カラム：作成テスト'
+    fill_in 'task_description', with: '説明カラム：作成テスト'
+    fill_in 'task_deadline', with: Time.current
 
     click_on '登録する'
 
-    expect(page).to have_content 'テスト3:タスク名'
-    expect(page).to have_content 'テスト3:説明'
+    expect(page).to have_content 'タスク名カラム：作成テスト'
+    expect(page).to have_content '説明カラム：作成テスト'
+    expect(page).to have_content Time.current
   end
 
   scenario "タスク詳細のテスト" do
     visit task_path(1)
     visit task_path(2)
+    visit task_path(3)
   end
 
-  scenario "タスクが作成日時の降順に並んでいるかのテスト" do
+  scenario "タスクが作成日時でソートできるかのテスト" do
     visit tasks_path
 
     task = all('.task_name')
     task_first = task.first
     task_last = task.last
 
-    expect(task_first).to have_content "テスト2:タスク名"
-    expect(task_last).to have_content "テスト1:タスク名"
+    expect(task_first).to have_content "タスク名カラム3"
+    expect(task_last).to have_content "タスク名カラム1"
   end
+
+  scenario "タスクが終了期限でソートできるかのテスト" do
+    visit tasks_path(sort_expired: "deadline")
+
+    task = all('.task_name')
+    task_first = task.first
+    task_last = task.last
+
+    expect(task_first).to have_content "タスク名カラム1"
+    expect(task_last).to have_content "タスク名カラム3"
+  end
+
 end


### PR DESCRIPTION
#21 
[ステップ14: 終了期限を追加しよう](https://diver.diveintocode.jp/curriculums/1277#jump-14)

- [ ] タスクに対して、終了期限を登録できるようにする

- [ ] 一覧画面で、終了期限でソートできるようにする（「終了期限でソートする」というボタン（リンク）を作成し、そのボタンを押すと、終了期限の降順に並び替えられたタスク一覧ページが出現するようにする！）

- [ ] 今回追加した機能のテストをfeature specで追記する

- [ ] PRしてレビューをしてもらったら、リリースしてみる