### PR TITLE
【Fixed】step15:ステータスを追加して、検索できるようにする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,7 @@ gem 'bcrypt', '3.1.11'
 gem 'carrierwave'
 gem 'mini_magick'
 gem 'ransack'
+gem 'enum_help'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'bootsnap', '>= 1.1.0', require: false
 gem 'bcrypt', '3.1.11'
 gem 'carrierwave'
 gem 'mini_magick'
+gem 'ransack'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,6 +96,8 @@ GEM
     dotenv-rails (2.7.5)
       dotenv (= 2.7.5)
       railties (>= 3.2, < 6.1)
+    enum_help (0.0.17)
+      activesupport (>= 3.0.0)
     erubi (1.8.0)
     execjs (2.7.0)
     factory_bot (5.0.2)
@@ -279,6 +281,7 @@ DEPENDENCIES
   coffee-rails (~> 4.2)
   database_cleaner
   dotenv-rails
+  enum_help
   factory_bot_rails
   faker
   launchy

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,6 +144,8 @@ GEM
     nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     pg (1.1.4)
+    polyamorous (2.3.0)
+      activerecord (>= 5.0)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
@@ -179,6 +181,12 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.19.0, < 2.0)
     rake (12.3.3)
+    ransack (2.3.0)
+      actionpack (>= 5.0)
+      activerecord (>= 5.0)
+      activesupport (>= 5.0)
+      i18n
+      polyamorous (= 2.3.0)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
@@ -281,6 +289,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 3.11)
   rails (~> 5.2.3)
+  ransack
   rspec-rails
   sass-rails (~> 5.0)
   selenium-webdriver

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,8 +2,8 @@ class TasksController < ApplicationController
   before_action :set_task, only: [:show, :edit, :update, :destroy]
 
   def index
-    @q = Task.ransack(params[:q])
-    @tasks = @q.result(distinct: true)
+    @query = Task.ransack(params[:q])
+    @tasks = @query.result(distinct: true).order(created_at: :desc)
   end
 
   def show

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -48,7 +48,7 @@ class TasksController < ApplicationController
   end
 
   def task_params
-    params.require(:task).permit(:name, :description, :deadline)
+    params.require(:task).permit(:name, :description, :deadline, :status)
   end
 
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -3,7 +3,7 @@ class TasksController < ApplicationController
 
   def index
     @query = Task.ransack(params[:q])
-    @tasks = @query.result(distinct: true).order(created_at: :desc)
+    @tasks = @query.result(distinct: true).sorted
   end
 
   def show

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,11 +2,8 @@ class TasksController < ApplicationController
   before_action :set_task, only: [:show, :edit, :update, :destroy]
 
   def index
-    if params[:sort_expired] == "deadline"
-      @tasks = Task.all.order(:deadline)
-    else
-      @tasks = Task.all.order(created_at: :desc)
-    end
+    @q = Task.ransack(params[:q])
+    @tasks = @q.result(distinct: true)
   end
 
   def show
@@ -48,7 +45,7 @@ class TasksController < ApplicationController
   end
 
   def task_params
-    params.require(:task).permit(:name, :description, :deadline, :status)
+    params.require(:task).permit(:name, :description, :deadline, :status, :q)
   end
 
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,4 +2,6 @@ class Task < ApplicationRecord
 
   validates :name, length: { in: 1..30 }
 
+  enum status: { "未着手": 0, "着手中": 1, "完了": 2, }
+
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -4,4 +4,6 @@ class Task < ApplicationRecord
 
   enum status: { untouched: 0, in_progress: 1, done: 2, }
 
+  scope :sorted, -> { order(created_at: :desc) }
+
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,6 +2,6 @@ class Task < ApplicationRecord
 
   validates :name, length: { in: 1..30 }
 
-  enum status: { "未着手": 0, "着手中": 1, "完了": 2, }
+  enum status: { untouched: 0, in_progress: 1, done: 2, }
 
 end

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -27,7 +27,7 @@
 
   <div class="field">
     <%= form.label :status, id: "task_status"  %>
-    <%= form.select :status, Task.statuses.keys.to_a, {} %>
+    <%= form.select :status, Task.statuses.keys.map{|key| [I18n.t("enums.task.status.#{key}"), key]} %>
   </div>
 
   <div class="actions">

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -25,6 +25,11 @@
     <%= form.datetime_field :deadline %>
   </div>
 
+  <div class="field">
+    <%= form.label :status, id: "task_status"  %>
+    <%= form.select :status, [ ["未着手", 0],["着手中", 1],["完了", 2] ] %>
+  </div>
+
   <div class="actions">
     <%= form.submit %>
   </div>

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -22,7 +22,7 @@
 
   <div class="field">
     <%= form.label :deadline, id: "task_deadline"  %>
-    <%= form.datetime_field :deadline %>
+    <%= form.date_select :deadline %>
   </div>
 
   <div class="field">

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -27,7 +27,7 @@
 
   <div class="field">
     <%= form.label :status, id: "task_status"  %>
-    <%= form.select :status, [ ["未着手", 0],["着手中", 1],["完了", 2] ] %>
+    <%= form.select :status, Task.statuses.keys.to_a, {} %>
   </div>
 
   <div class="actions">

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -4,26 +4,30 @@
 
 <br>
 
-<%= search_form_for @q do |f| %>
-  <%= f.search_field :name_or_status_cont, placeholder: "タスク名 or ステータス" %>
-  <%= f.submit "検索" %>
+<%= search_form_for @query do |form| %>
+  <%= form.label :task_search, id: "task_search" %>
+  <br>
+  <%= form.select :status_eq, Task.statuses.map{|key, value| [Task.statuses_i18n[key], value]}, include_blank: '指定なし' %>
+  <%= form.search_field :name_cont, placeholder: "タスク名" %>
+  <%= form.submit "検索" %>
 <% end %>
 
 <table>
   <thead>
     <tr>
-      <th><%= sort_link(@q, :status, t('views.tasks.status')) %></th>
-      <th><%= sort_link(@q, :name, t('views.tasks.name')) %></th>
-      <th><%= sort_link(@q, :description, t('views.tasks.description')) %></th>
-      <th><%= sort_link(@q, :description, t('views.tasks.deadline')) %></th>
+      <th><%= sort_link(@query, :status, t('views.tasks.status')) %></th>
+      <th><%= sort_link(@query, :name, t('views.tasks.name')) %></th>
+      <th><%= sort_link(@query, :description, t('views.tasks.description')) %></th>
+      <th><%= sort_link(@query, :description, t('views.tasks.deadline')) %></th>
       <th colspan="2"></th>
     </tr>
   </thead>
 
   <tbody>
+
     <% @tasks.each do |task| %>
       <tr>
-        <td><%= task.status %></td>
+        <td><%= task.status_i18n %></td>
         <td><%= link_to task.name, task, class: 'task_name' %></td>
         <td><%= task.description %></td>
         <td><%= task.deadline %></td>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -28,7 +28,7 @@
         <td><%= task.status_i18n %></td>
         <td><%= link_to task.name, task, class: 'task_name' %></td>
         <td><%= task.description %></td>
-        <td><%= task.deadline %></td>
+        <td><%= task.deadline.strftime("%Y-%m-%d") %></td>
         <td><%= link_to t('views.tasks.edit'), edit_task_path(task) %></td>
         <td><%= link_to t('views.tasks.destroy'), task, method: :delete, data: { confirm: "このタスクを削除します。よろしいですか？" } %></td>
       </tr>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -4,16 +4,18 @@
 
 <br>
 
-<%= link_to "作成日時順", tasks_path %>
-<%= link_to "終了期限順", tasks_path(sort_expired: "deadline") %>
+<%= search_form_for @q do |f| %>
+  <%= f.search_field :name_or_status_cont, placeholder: "タスク名 or ステータス" %>
+  <%= f.submit "検索" %>
+<% end %>
 
 <table>
   <thead>
     <tr>
-      <th>ステータス</th>
-      <th><%= t('views.tasks.name') %></th>
-      <th><%= t('views.tasks.description') %></th>
-      <th><%= t('views.tasks.deadline') %></th>
+      <th><%= sort_link(@q, :status, t('views.tasks.status')) %></th>
+      <th><%= sort_link(@q, :name, t('views.tasks.name')) %></th>
+      <th><%= sort_link(@q, :description, t('views.tasks.description')) %></th>
+      <th><%= sort_link(@q, :description, t('views.tasks.deadline')) %></th>
       <th colspan="2"></th>
     </tr>
   </thead>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -10,9 +10,10 @@
 <table>
   <thead>
     <tr>
+      <th>ステータス</th>
       <th><%= t('views.tasks.name') %></th>
       <th><%= t('views.tasks.description') %></th>
-      <th>終了期限</th>
+      <th><%= t('views.tasks.deadline') %></th>
       <th colspan="2"></th>
     </tr>
   </thead>
@@ -20,6 +21,7 @@
   <tbody>
     <% @tasks.each do |task| %>
       <tr>
+        <td><%= task.status %></td>
         <td><%= link_to task.name, task, class: 'task_name' %></td>
         <td><%= task.description %></td>
         <td><%= task.deadline %></td>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -5,8 +5,6 @@
 <br>
 
 <%= search_form_for @query do |form| %>
-  <%= form.label :task_search, id: "task_search" %>
-  <br>
   <%= form.select :status_eq, Task.statuses.map{|key, value| [Task.statuses_i18n[key], value]}, include_blank: '指定なし' %>
   <%= form.search_field :name_cont, placeholder: "タスク名" %>
   <%= form.submit "検索" %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -4,7 +4,7 @@
 
 <br>
 
-<p>ステータス：<strong><%= @task.status %></strong></p>
+<p><%= t('views.tasks.name') %>：<strong><%= @task.status %></strong></p>
 <p><%= t('views.tasks.name') %>：<strong><%= @task.name %></strong></p>
 <p><%= t('views.tasks.description') %>：<strong><%= @task.description %></strong></p>
 <p><%= t('views.tasks.deadline') %>：<strong><%= @task.deadline %></strong></p>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -4,9 +4,10 @@
 
 <br>
 
+<p>ステータス：<strong><%= @task.status %></strong></p>
 <p><%= t('views.tasks.name') %>：<strong><%= @task.name %></strong></p>
 <p><%= t('views.tasks.description') %>：<strong><%= @task.description %></strong></p>
-<p>終了期限：<strong><%= @task.deadline %></strong></p>
+<p><%= t('views.tasks.deadline') %>：<strong><%= @task.deadline %></strong></p>
 
 
 <br>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -7,7 +7,7 @@
 <p><%= t('views.tasks.name') %>：<strong><%= @task.status_i18n %></strong></p>
 <p><%= t('views.tasks.name') %>：<strong><%= @task.name %></strong></p>
 <p><%= t('views.tasks.description') %>：<strong><%= @task.description %></strong></p>
-<p><%= t('views.tasks.deadline') %>：<strong><%= @task.deadline %></strong></p>
+<p><%= t('views.tasks.deadline') %>：<strong><%= @task.deadline.strftime("%Y-%m-%d") %></strong></p>
 
 
 <br>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -4,7 +4,7 @@
 
 <br>
 
-<p><%= t('views.tasks.name') %>：<strong><%= @task.status %></strong></p>
+<p><%= t('views.tasks.name') %>：<strong><%= @task.status_i18n %></strong></p>
 <p><%= t('views.tasks.name') %>：<strong><%= @task.name %></strong></p>
 <p><%= t('views.tasks.description') %>：<strong><%= @task.description %></strong></p>
 <p><%= t('views.tasks.deadline') %>：<strong><%= @task.deadline %></strong></p>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,5 +1,10 @@
----
 ja:
+  enums:
+    task:
+      status:
+        untouched: "未着手"
+        in_progress: "着手中"
+        done: "完了"
   activerecord:
     errors:
       messages:

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -7,3 +7,4 @@ ja:
         name: タスク名
         description: 説明
         deadline: 終了期限
+        status: ステータス

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -8,3 +8,4 @@ ja:
         description: 説明
         deadline: 終了期限
         status: ステータス
+        task_search: タスク検索

--- a/config/locales/views/tasks/ja.yml
+++ b/config/locales/views/tasks/ja.yml
@@ -4,6 +4,7 @@ ja:
       name: タスク名
       description: 説明
       deadline: 終了期限
+      status: ステータス
       create: 新規作成
       show: 詳細
       edit: 編集

--- a/db/migrate/20190917043830_add_status_to_tasks.rb
+++ b/db/migrate/20190917043830_add_status_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddStatusToTasks < ActiveRecord::Migration[5.2]
+  def change
+    add_column :tasks, :status, :integer, default: 0, null: false
+  end
+end

--- a/db/migrate/20190918014636_add_index_to_task_name.rb
+++ b/db/migrate/20190918014636_add_index_to_task_name.rb
@@ -1,0 +1,5 @@
+class AddIndexToTaskName < ActiveRecord::Migration[5.2]
+  def change
+    add_index :tasks, :name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_16_065215) do
+ActiveRecord::Schema.define(version: 2019_09_17_043830) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2019_09_16_065215) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "deadline", default: -> { "now()" }, null: false
+    t.integer "status", default: 0, null: false
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_17_043830) do
+ActiveRecord::Schema.define(version: 2019_09_18_014636) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -22,6 +22,7 @@ ActiveRecord::Schema.define(version: 2019_09_17_043830) do
     t.datetime "updated_at", null: false
     t.datetime "deadline", default: -> { "now()" }, null: false
     t.integer "status", default: 0, null: false
+    t.index ["name"], name: "index_tasks_on_name"
   end
 
 end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -5,6 +5,7 @@ FactoryBot.define do
     created_at { Time.current }
     updated_at { Time.current }
     deadline { Time.current }
+    status { 'done' }
   end
 
   factory :task_test2, class: Task do
@@ -13,6 +14,7 @@ FactoryBot.define do
     created_at { Time.current + 1.days }
     updated_at { Time.current + 2.days }
     deadline { Time.current + 3.days }
+    status { 'in_progress' }
   end
 
   factory :task_test3, class: Task do
@@ -21,5 +23,6 @@ FactoryBot.define do
     created_at { Time.current + 2.days }
     updated_at { Time.current + 3.days }
     deadline { Time.current + 4.days }
+    status { 'untouched' }
   end
 end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -2,27 +2,27 @@ FactoryBot.define do
   factory :task_test1, class: Task do
     name { 'タスク名カラム1' }
     description { '説明カラム1' }
-    created_at { Time.current }
-    updated_at { Time.current }
-    deadline { Time.current }
+    created_at { DateTime.current }
+    updated_at { DateTime.current }
+    deadline { DateTime.current }
     status { 'done' }
   end
 
   factory :task_test2, class: Task do
     name { 'タスク名カラム2' }
     description { '説明カラム2' }
-    created_at { Time.current + 1.days }
-    updated_at { Time.current + 2.days }
-    deadline { Time.current + 3.days }
+    created_at { DateTime.current + 1.days }
+    updated_at { DateTime.current + 2.days }
+    deadline { DateTime.current + 3.days }
     status { 'in_progress' }
   end
 
   factory :task_test3, class: Task do
     name { 'タスク名カラム3' }
     description { '説明カラム3' }
-    created_at { Time.current + 2.days }
-    updated_at { Time.current + 3.days }
-    deadline { Time.current + 4.days }
+    created_at { DateTime.current + 2.days }
+    updated_at { DateTime.current + 3.days }
+    deadline { DateTime.current + 4.days }
     status { 'untouched' }
   end
 end

--- a/spec/features/task.spec.rb
+++ b/spec/features/task.spec.rb
@@ -12,15 +12,15 @@ RSpec.feature "タスク管理機能", type: :feature do
 
     expect(page).to have_content 'タスク名カラム1'
     expect(page).to have_content '説明カラム1'
-    expect(page).to have_content Time.current
+    expect(page).to have_content DateTime.current.strftime("%Y-%m-%d")
     expect(page).to have_content '完了'
     expect(page).to have_content 'タスク名カラム2'
     expect(page).to have_content '説明カラム2'
-    expect(page).to have_content Time.current + 3.days
+    expect(page).to have_content (DateTime.current + 3.days).strftime("%Y-%m-%d")
     expect(page).to have_content '着手中'
     expect(page).to have_content 'タスク名カラム3'
     expect(page).to have_content '説明カラム3'
-    expect(page).to have_content Time.current + 4.days
+    expect(page).to have_content (DateTime.current + 4.days).strftime("%Y-%m-%d")
     expect(page).to have_content '未着手'
   end
 
@@ -29,14 +29,16 @@ RSpec.feature "タスク管理機能", type: :feature do
 
     fill_in 'task_name', with: 'タスク名カラム：作成テスト'
     fill_in 'task_description', with: '説明カラム：作成テスト'
-    fill_in 'task_deadline', with: Time.current + 3.days
+    select DateTime.current.year, from: 'task_deadline_1i'
+    select DateTime.current.month, from: 'task_deadline_2i'
+    select DateTime.current.day, from: 'task_deadline_3i'
     select '未着手', from: 'ステータス'
 
     click_on '登録する'
 
     expect(page).to have_content 'タスク名カラム：作成テスト'
     expect(page).to have_content '説明カラム：作成テスト'
-    expect(page).to have_content Time.current + 3.days
+    expect(page).to have_content DateTime.current.strftime("%Y-%m-%d")
     expect(page).to have_content '未着手'
   end
 

--- a/spec/features/task.spec.rb
+++ b/spec/features/task.spec.rb
@@ -13,12 +13,15 @@ RSpec.feature "タスク管理機能", type: :feature do
     expect(page).to have_content 'タスク名カラム1'
     expect(page).to have_content '説明カラム1'
     expect(page).to have_content Time.current
+    expect(page).to have_content '完了'
     expect(page).to have_content 'タスク名カラム2'
     expect(page).to have_content '説明カラム2'
     expect(page).to have_content Time.current + 3.days
+    expect(page).to have_content '着手中'
     expect(page).to have_content 'タスク名カラム3'
     expect(page).to have_content '説明カラム3'
     expect(page).to have_content Time.current + 4.days
+    expect(page).to have_content '未着手'
   end
 
   scenario "タスク作成のテスト" do
@@ -26,13 +29,15 @@ RSpec.feature "タスク管理機能", type: :feature do
 
     fill_in 'task_name', with: 'タスク名カラム：作成テスト'
     fill_in 'task_description', with: '説明カラム：作成テスト'
-    fill_in 'task_deadline', with: Time.current
+    fill_in 'task_deadline', with: Time.current + 3.days
+    select '未着手', from: 'ステータス'
 
     click_on '登録する'
 
     expect(page).to have_content 'タスク名カラム：作成テスト'
     expect(page).to have_content '説明カラム：作成テスト'
-    expect(page).to have_content Time.current
+    expect(page).to have_content Time.current + 3.days
+    expect(page).to have_content '未着手'
   end
 
   scenario "タスク詳細のテスト" do
@@ -41,7 +46,7 @@ RSpec.feature "タスク管理機能", type: :feature do
     visit task_path(3)
   end
 
-  scenario "タスクが作成日時でソートできるかのテスト" do
+  scenario "タスクが作成日時順（降順）に並んでいるかのテスト" do
     visit tasks_path
 
     task = all('.task_name')
@@ -52,15 +57,40 @@ RSpec.feature "タスク管理機能", type: :feature do
     expect(task_last).to have_content "タスク名カラム1"
   end
 
-  scenario "タスクが終了期限でソートできるかのテスト" do
-    visit tasks_path(sort_expired: "deadline")
+  scenario "タスク検索のテスト" do
+    # ステータス検索
+    visit tasks_path
 
-    task = all('.task_name')
-    task_first = task.first
-    task_last = task.last
+    select '未着手'
 
-    expect(task_first).to have_content "タスク名カラム1"
-    expect(task_last).to have_content "タスク名カラム3"
+    click_on '検索'
+
+    expect(page).not_to have_content "タスク名カラム1"
+    expect(page).not_to have_content "タスク名カラム2"
+    expect(page).to have_content "タスク名カラム3"
+
+    # タスク名検索
+    visit tasks_path
+
+    fill_in with: 'カラム2'
+
+    click_on '検索'
+
+    expect(page).not_to have_content "タスク名カラム1"
+    expect(page).to have_content "タスク名カラム2"
+    expect(page).not_to have_content "タスク名カラム3"
+
+    # ステータス+タスク名検索
+    visit tasks_path
+
+    select '未着手'
+    fill_in with: 'カラム2'
+
+    click_on '検索'
+
+    expect(page).not_to have_content "タスク名カラム1"
+    expect(page).not_to have_content "タスク名カラム2"
+    expect(page).not_to have_content "タスク名カラム3"
   end
 
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -10,4 +10,16 @@ RSpec.describe Task, type: :model do
     task = Task.new(name: 'テスト！', description: '成功テスト')
     expect(task).to be_valid
   end
+
+  it "scopeのテスト" do
+    FactoryBot.create(:task_test1)
+    FactoryBot.create(:task_test2)
+    FactoryBot.create(:task_test3)
+    tasks = Task.all
+    tasks_without_scope = tasks.order(created_at: :desc)
+    tasks_with_scope = tasks.sorted
+    expect(tasks_without_scope.first).to eq tasks_with_scope.first
+    expect(tasks_without_scope.first).not_to eq tasks_with_scope.last
+  end
+
 end


### PR DESCRIPTION
#24 
[ステップ15: ステータスを追加して、検索できるようにしよう](https://diver.diveintocode.jp/curriculums/1277#jump-15)

- [x] ステータス（未着手・着手中・完了）を追加する
【+α要件】初学者ではない場合はstateを管理するGemを導入しても構わない。

- [x] 一覧画面でタイトルとステータスで絞り込み検索ができるようにする（タイトルにのみ値が入っていた場合はタイトルのみで検索し、ステータスにのみ値が入っていた場合はステータスのみで検索し、両方に値が入っていた場合は両方成り立つもの（and検索）を検索できるようにする）
【+α要件】初学者ではない場合はransackなどの検索の実装を便利にするGemを導入しても構わない。そうでない場合は、where文などを使う。

- [x] 検索を使用した時と、使用していない時とで、ログを見て発行されるSQLの変化を確認する。以降のステップでも必要に応じて確認する癖をつける。

- [x] 検索インデックスを貼る。
【+α要件】 ある程度まとまったテストデータを用意して log/development.log を見ながら動作確認を行い、インデックスの追加により速度が改善されることを確認する。
【+α要件】explainメソッドなどを使用して、データベース側でのインデックス使用状況なども見る。

- [x] 検索のロジックが書けたら、それをコントローラからモデルに移して（scopeにして）、その記述に対するmodelのテストを追加する（feature specも追記する）。