### PR TITLE
【Fixed】step21:ユーザの管理画面を実装する

### DIFF
--- a/app/assets/stylesheets/tasks.scss
+++ b/app/assets/stylesheets/tasks.scss
@@ -82,7 +82,9 @@ transform: rotate(-45deg);
 }
 
 // 入力フォーム枠
-#task_name, #task_description, #task_deadline_1i, #task_deadline_2i, #task_deadline_3i, #task_status, #task_priority, #q_status_eq, [type="search"] {
+#task_name, #task_description, #task_deadline_1i, #task_deadline_2i, #task_deadline_3i, #task_status, #task_priority,
+#user_name, ,#user_email, #user_password, #user_password_confirmation, #user_admin,
+#q_status_eq, [type="search_task_name"], [type="search_user_name"], [type="search_user_email"] {
   color: #000000;
   background-color: #FFFFFF;
   background-clip: padding-box;
@@ -114,7 +116,7 @@ transform: rotate(-45deg);
 }
 
 // ステータスセレクト枠、優先順位セレクト枠
-#task_status, #task_priority {
+#task_status, #task_priority, #user_admin {
     display: block;
     width: 100%;
     height: calc(1.5em + 0.75rem + 2px);
@@ -128,6 +130,17 @@ transform: rotate(-45deg);
 // ステータスセレクト(検索)枠
 #q_status_eq {
   width: 30%;
+  height: calc(1.5em + 0.75rem + 2.5px);
+  padding: 0.375rem 0.75rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5;
+  transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+
+// タスク名検索フォーム
+[type="search_task_name"] {
+  width: 55%;
   height: calc(1.5em + 0.75rem + 2px);
   padding: 0.375rem 0.75rem;
   font-size: 1rem;
@@ -136,10 +149,21 @@ transform: rotate(-45deg);
   transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
 }
 
-// テキストフィールド（検索）枠
-[type="search"] {
-  width: 55%;
-  height: calc(1.5em + 0.75rem + 3.5px);
+// ユーザ名検索フォーム
+[type="search_user_name"] {
+  width: 25%;
+  height: calc(1.5em + 0.75rem + 2px);
+  padding: 0.375rem 0.75rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5;
+  transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+
+// メールアドレス検索フォーム
+[type="search_user_email"] {
+  width: 40%;
+  height: calc(1.5em + 0.75rem + 2px);
   padding: 0.375rem 0.75rem;
   font-size: 1rem;
   font-weight: 400;
@@ -155,7 +179,7 @@ transform: rotate(-45deg);
   border: 0;
   outline: 1px solid #007BFF;
   outline-offset: -1px;
-  height: calc(1.5em + 0.75rem + 2.5px);
+  height: calc(1.5em + 0.75rem + 2px);
   padding: 0.375rem 0.75rem;
   font-size: 1rem;
   font-weight: 400;

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,73 @@
+class Admin::UsersController < ApplicationController
+  before_action :authenticate_user
+  before_action :require_adimn
+  before_action :set_user, only: [:show, :edit, :update, :destroy]
+
+  # before_action :admin_user, only: [:create, :update]
+
+
+  def index
+    @query = User.ransack(params[:q])
+    @users = @query.result(distinct: true).sorted.page(params[:page])
+    @tasks = Task.all
+  end
+
+  def show
+    @query = Task.where(user_id: params[:id]).ransack(params[:q])
+    @tasks = @query.result(distinct: true).sorted.page(params[:page])
+  end
+
+  def new
+    @user = User.new
+  end
+
+  def edit
+  end
+
+  def create
+    @user = User.new(user_params)
+    if @user.save
+      redirect_to admin_user_path(@user), notice:  "#{@user.name}さんのアカウントを作成しました。"
+    else
+      render :new
+    end
+  end
+
+  def update
+    if @user.update(user_params)
+      redirect_to admin_user_path(@user), notice: "#{@user.name}さんの情報を更新しました。"
+    else
+      render :edit
+    end
+  end
+
+  def destroy
+    if @user == User.first && @user == User.last
+      redirect_to admin_users_path, notice: "ユーザがゼロになってしまう為、削除できません。"
+    else
+      if @user.admin == true
+        redirect_to admin_users_path, notice: "管理者権限を持つユーザは削除できません。"
+      else
+        @user.destroy
+        redirect_to admin_users_path, notice: "ユーザを削除しました。"
+      end
+    end
+  end
+
+  private
+
+  def set_user
+    @user = User.find(params[:id])
+  end
+
+  def user_params
+    params.require(:user).permit(:name, :email, :password, :password_confirmation, :admin)
+  end
+
+  def require_adimn
+    if current_user.admin != true
+      flash[:notice] = "権限がありません。"
+      redirect_to tasks_path
+    end
+  end
+end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -52,12 +52,12 @@ class TasksController < ApplicationController
   end
 
   def check_task_authority
-    if Task.find(params[:id].to_i).user_id.to_i == current_user.id
-    else
-      redirect_to tasks_path, notice: '権限がありません'
+    if current_user.admin != true
+      if Task.find(params[:id].to_i).user_id.to_i == current_user.id
+      else
+        redirect_to tasks_path, notice: '権限がありません。'
+      end
     end
   end
-
-
 
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -22,7 +22,7 @@ class UsersController < ApplicationController
     @user = User.new(user_params)
     if @user.save
       session[:user_id] = @user.id
-      redirect_to user_path(@user.id), notice:  t('controllers.users_controller.create.notice')
+      redirect_to user_path(@user.id), notice: t('controllers.users_controller.create.notice')
     else
       render :new
     end
@@ -52,9 +52,11 @@ class UsersController < ApplicationController
   end
 
   def ensure_correct_user
-    if current_user.id != params[:id].to_i
-      flash[:notice] = "権限がありません。"
-      redirect_to tasks_path
+    if current_user.admin != true
+      if current_user.id != params[:id].to_i
+        flash[:notice] = "権限がありません。"
+        redirect_to tasks_path
+      end
     end
   end
 

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -15,7 +15,7 @@ module SessionsHelper
   end
 
   def forbid_login_user
-    if current_user !=nil
+    if current_user !=nil && current_user.admin != true
       flash[:notice] = "すでにログインしています。"
       redirect_to tasks_path
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -10,7 +10,12 @@ class User < ApplicationRecord
 
   has_secure_password
   validates :password,
-    length: { minimum: 6 }
+    length: { minimum: 6 }, allow_nil: true
 
-  has_many :tasks
+  has_many :tasks, dependent: :destroy
+
+  scope :sorted, -> { order(created_at: :desc) }
+
+  paginates_per 10
+
 end

--- a/app/views/admin/users/edit.html.erb
+++ b/app/views/admin/users/edit.html.erb
@@ -1,0 +1,73 @@
+<div class="row">
+  <div class="col-8 offset-2">
+
+    <div class="card border-primary rounded-0">
+      <div class="card-header bg-transparent border-primary text-center">
+        <strong class="text-primary"><%= t('views.users.edit_html.title') %></strong>
+      </div>
+      <div class="card-body">
+        <%= form_with(model: [:admin, @user], local: true) do |form| %>
+          <% if @user.errors.any? %>
+            <div id="error_explanation" class="row" >
+              <div class="col-12 text-left alert alert-danger rounded-0" role="alert">
+                <strong class="alert-heading">⚠︎ <%= pluralize(@user.errors.count, "件") %> のエラーが発生しました</strong>
+                <ul class="mb-0">
+                  <% @user.errors.full_messages.each do |message| %>
+                    <li><%= message %></li>
+                  <% end %>
+                </ul>
+              </div>
+            </div>
+            <br>
+          <% end %>
+
+          <div class="row d-flex align-items-center form-group">
+            <div class="col-4 text-left">
+              <strong class="text-primary">権限</strong>
+            </div>
+            <div class="col-8 text-left">
+              <%= form.select :admin, [["一般", false], ["管理者", true]] %>
+            </div>
+          </div>
+          <hr color="#007BFF">
+          <div class="row d-flex align-items-center form-group">
+            <div class="col-4 text-left">
+              <strong class="text-primary"><%= t('views.users.name') %></strong>
+            </div>
+            <div class="col-8 text-left">
+              <%= form.text_field :name, placeholder: "名前を入力してください", class: "form-control rounded-0" %>
+            </div>
+          </div>
+          <hr color="#007BFF">
+          <div class="row d-flex align-items-center form-group">
+            <div class="col-4 text-left">
+              <strong class="text-primary"><%= t('views.users.email') %></strong>
+            </div>
+            <div class="col-8 text-left">
+              <%= form.email_field :email, placeholder: "email@example.com", class: "form-control rounded-0" %>
+            </div>
+          </div>
+          <hr color="#007BFF">
+
+          <%= form.hidden_field :password, placeholder: "6文字以上", class: "form-control rounded-0" %>
+          <%= form.hidden_field :password_confirmation, placeholder: "6文字以上（確認用）", class: "form-control rounded-0" %>
+
+          <div class="actions text-center">
+            <%= form.submit class: "btn btn-outline-primary rounded-0" %>
+          </div>
+
+        <% end %>
+
+      </div>
+    </div>
+
+    <br>
+
+    <div class="row">
+      <div class="col-6 offset-3 text-center">
+        <%= link_to t('views.users.back'), admin_user_url(@user), class: "btn btn-outline-primary rounded-0" %>
+      </div>
+    </div>
+
+  </div>
+</div>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,0 +1,89 @@
+<div class="row">
+  <div class="col-8 offset-2">
+
+    <div class="card border-primary rounded-0">
+      <div class="card-header bg-transparent border-primary text-center">
+        <div class="row d-flex align-items-center">
+          <div class="col-7 text-right">
+            <strong class="text-primary"><%= link_to t('views.users.index_html.title'), admin_users_path %></strong>
+          </div>
+          <div class="col-5 text-right">
+            <strong class="text-primary"><%= link_to t('views.users.create'), new_admin_user_path, class: 'btn btn-outline-primary btn-sm rounded-0' %></strong>
+          </div>
+        </div>
+      </div>
+      <div class="card-header bg-transparent border-primary">
+        <div class="row d-flex align-items-center">
+          <div class="col-12 text-center">
+            <%= search_form_for [:admin, @query] do |form| %>
+              <%= form.search_field :name_cont, placeholder: "ユーザ名", type: 'search_user_name' %>
+              <%= form.search_field :email_cont, placeholder: "メールアドレス", type: 'search_user_email' %>
+              <%= form.submit "検索", class: 'search_btn' %>
+            <% end %>
+          </div>
+        </div>
+      </div>
+      <div class="card-body">
+        <div class="row d-flex align-items-center">
+          <div class="col-10 offset-1">
+            <table width="100%">
+              <thead>
+                <tr class="text-center border-bottom border-primary">
+                  <th><%= sort_link(@query, :admin, "権限") %></th>
+                  <th><%= sort_link(@query, :name, t('views.users.name')) %></th>
+                  <th><%= sort_link(@query, :email, t('views.users.email')) %></th>
+                  <th><%= sort_link(@query, :created_at, t('views.users.created_at')) %></th>
+                  <th><font color="#007BFF">タスク数</font></th>
+                  <th colspan="1"></th>
+                </tr>
+                <tr class="border-bottom border-primary">
+                  <th></th>
+                  <th></th>
+                  <th></th>
+                  <th></th>
+                  <th></th>
+                  <th></th>
+                </tr>
+              </thead>
+              <tbody>
+                <% @users.each do |user| %>
+                  <tr class="text-center border-bottom border-primary">
+                    <% if user.admin == true %>
+                      <td>管理者</td>
+                    <% else %>
+                      <td> 一般 </td>
+                    <% end %>
+                    <td><%= link_to user.name, admin_user_url(user), class: 'user_name' %></td>
+                    <td><%= user.email %></td>
+                    <td><%= user.created_at.strftime("%Y年%m月%d日") %></td>
+                    <td><%= link_to Task.where(user_id: user.id).length, admin_user_url(user), class: 'task_name' %></td>
+                    <% if user.admin == true %>
+                      <td colspan="1"></td>
+                    <% else %>
+                      <td><%= link_to '×', admin_user_path(user.id), method: :delete, data: { confirm: "このユーザを削除します。よろしいですか？" } %></td>
+                    <% end %>
+                  </tr>
+                <% end %>
+              </tbody>
+            </table>
+            <br>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-8 offset-2">
+            <%= paginate @users %>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <br>
+
+    <div class="row">
+      <div class="col-6 offset-3 text-center">
+        <%= link_to '戻る', tasks_path, class: "btn btn-outline-primary rounded-0" %>
+      </div>
+    </div>
+
+  </div>
+</div>

--- a/app/views/admin/users/new.html.erb
+++ b/app/views/admin/users/new.html.erb
@@ -1,0 +1,87 @@
+<div class="row">
+  <div class="col-8 offset-2">
+
+    <div class="card border-primary rounded-0">
+      <div class="card-header bg-transparent border-primary text-center">
+        <strong class="text-primary"><%= t('views.users.new_html.title') %></strong>
+      </div>
+      <div class="card-body">
+        <%= form_with(model: [:admin, @user], local: true) do |form| %>
+          <% if @user.errors.any? %>
+            <div id="error_explanation" class="row" >
+              <div class="col-12 text-left alert alert-danger rounded-0" role="alert">
+                <strong class="alert-heading">⚠︎ <%= pluralize(@user.errors.count, "件") %> のエラーが発生しました</strong>
+                <ul class="mb-0">
+                  <% @user.errors.full_messages.each do |message| %>
+                    <li><%= message %></li>
+                  <% end %>
+                </ul>
+              </div>
+            </div>
+            <br>
+          <% end %>
+
+          <div class="row d-flex align-items-center form-group">
+            <div class="col-4 text-left">
+              <strong class="text-primary">権限</strong>
+            </div>
+            <div class="col-8 text-left">
+              <%= form.select :admin, [["一般", false], ["管理者", true]] %>
+            </div>
+          </div>
+          <hr color="#007BFF">
+          <div class="row d-flex align-items-center form-group">
+            <div class="col-4 text-left">
+              <strong class="text-primary"><%= t('views.users.name') %></strong>
+            </div>
+            <div class="col-8 text-left">
+              <%= form.text_field :name, placeholder: "名前を入力してください", class: "form-control rounded-0" %>
+            </div>
+          </div>
+          <hr color="#007BFF">
+          <div class="row d-flex align-items-center form-group">
+            <div class="col-4 text-left">
+              <strong class="text-primary"><%= t('views.users.email') %></strong>
+            </div>
+            <div class="col-8 text-left">
+              <%= form.email_field :email, placeholder: "email@example.com", class: "form-control rounded-0" %>
+            </div>
+          </div>
+          <hr color="#007BFF">
+          <div class="row d-flex align-items-center form-group">
+            <div class="col-4 text-left">
+              <strong class="text-primary"><%= t('views.users.password') %></strong>
+            </div>
+            <div class="col-8 text-left">
+              <%= form.password_field :password, placeholder: "6文字以上", class: "form-control rounded-0" %>
+            </div>
+          </div>
+          <hr color="#007BFF">
+          <div class="row d-flex align-items-center form-group">
+            <div class="col-4 text-left">
+              <strong class="text-primary"><%= t('views.users.password_confirmation') %></strong>
+            </div>
+            <div class="col-8 text-left">
+              <%= form.password_field :password_confirmation, placeholder: "6文字以上（確認用）", class: "form-control rounded-0" %>
+            </div>
+          </div>
+          <hr color="#007BFF">
+
+          <div class="actions text-center">
+            <%= form.submit class: "btn btn-outline-primary rounded-0" %>
+          </div>
+
+        <% end %>
+      </div>
+    </div>
+
+    <br>
+
+    <div class="row">
+      <div class="col-6 offset-3 text-center">
+        <%= link_to '戻る', admin_users_path, class: "btn btn-outline-primary rounded-0" %>
+      </div>
+    </div>
+
+  </div>
+</div>

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,0 +1,141 @@
+<div class="row">
+  <div class="col-8 offset-2">
+
+    <div class="card border-primary rounded-0">
+      <div class="card-header bg-transparent border-primary">
+        <div class="row d-flex align-items-center">
+          <div class="col-7 text-right">
+            <strong class="text-primary"><%= @user.name %>さんの<%= t('views.users.show_html.title') %></strong>
+          </div>
+          <div class="col-5 text-right">
+            <strong class="text-primary"><%= link_to t('views.users.edit'), edit_admin_user_path(@user), class: 'btn btn-outline-primary btn-sm rounded-0' %></strong>
+          </div>
+        </div>
+      </div>
+      <div class="card-body">
+        <div class="row">
+          <div class="col-3 text-left">
+            <strong class="text-primary">権限</strong>
+          </div>
+          <div class="col-0.5 text-center">：</div>
+          <div class="col-8.5 text-left">
+            <% if @user.admin == true %>
+              管理者
+            <% else %>
+              一般
+            <% end %>
+          </div>
+        </div>
+        <hr color="#007BFF">
+        <div class="row">
+          <div class="col-3 text-left">
+            <strong class="text-primary"><%= t('views.users.name') %></strong>
+          </div>
+          <div class="col-0.5 text-center">：</div>
+          <div class="col-8.5 text-left">
+            <%= @user.name %>
+          </div>
+        </div>
+        <hr color="#007BFF">
+        <div class="row">
+          <div class="col-3 text-left">
+            <strong class="text-primary"><%= t('views.users.email') %></strong>
+          </div>
+          <div class="col-0.5 text-center">：</div>
+          <div class="col-8.5 text-left">
+            <%= @user.email %>
+          </div>
+        </div>
+        <hr color="#007BFF">
+        <div class="row">
+          <div class="col-3 text-left">
+            <strong class="text-primary"><%= t('views.users.created_at') %></strong>
+          </div>
+          <div class="col-0.5 text-center">：</div>
+          <div class="col-8.5 text-left">
+            <%= @user.created_at.strftime("%Y年%m月%d日 %H時%M分") %>
+          </div>
+        </div>
+        <% unless @user.created_at == @user.updated_at %>
+          <hr color="#007BFF">
+          <div class="row">
+            <div class="col-3 text-left">
+              <strong class="text-primary"><%= t('views.users.updated_at') %></strong>
+            </div>
+            <div class="col-0.5 text-center">：</div>
+            <div class="col-8.5 text-left">
+              <%= @user.updated_at.strftime("%Y年%m月%d日 %H時%M分") %>
+            </div>
+          </div>
+        <% end %>
+      </div>
+    </div>
+
+    <br>
+
+    <div class="card border-primary rounded-0">
+      <div class="card-header bg-transparent border-primary text-center">
+        <div class="row d-flex align-items-center">
+          <div class="col-6 offset-3">
+            <strong class="text-primary"><%= @user.name %>さんのタスク一覧</strong>
+          </div>
+        </div>
+      </div>
+      <div class="card-body">
+        <div class="row d-flex align-items-center">
+          <div class="col-10 offset-1">
+            <% if @tasks != [] %>
+              <table width="100%">
+                <thead>
+                  <tr class="text-center border-bottom border-primary">
+                    <th><%= sort_link(@query, :priority, t('views.tasks.priority')) %></th>
+                    <th><%= sort_link(@query, :status, t('views.tasks.status')) %></th>
+                    <th><%= sort_link(@query, :name, t('views.tasks.name')) %></th>
+                    <th><%= sort_link(@query, :deadline, t('views.tasks.deadline')) %></th>
+                  </tr>
+                  <tr class="border-bottom border-primary">
+                    <th></th>
+                    <th></th>
+                    <th></th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <% @tasks.each do |task| %>
+                    <tr class="text-center border-bottom border-primary">
+                      <td><%= task.priority_i18n %></td>
+                      <td><%= task.status_i18n %></td>
+                      <td><%= task.name %></td>
+                      <td><%= task.deadline.strftime("%Y年%m月%d日") %></td>
+                    </tr>
+                  <% end %>
+                </tbody>
+              </table>
+              <br>
+            <% else %>
+              <div class="row d-flex align-items-center">
+                <div class="col-10 offset-1 text-center">
+                  <strong>タスクがありません</strong>
+                </div>
+              </div>
+            <% end %>
+          </div>
+        </div>
+        <div class="row">
+          <div class="col-8 offset-2">
+            <%= paginate @tasks %>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <br>
+
+    <div class="row">
+      <div class="col-6 offset-3 text-center">
+        <%= link_to '戻る', admin_users_path, class: "btn btn-outline-primary rounded-0" %>
+      </div>
+    </div>
+
+  </div>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -31,6 +31,11 @@
           <div class="collapse navbar-collapse" id="gnavi">
             <ul class="navbar-nav ml-auto float-right">
               <% if logged_in? %>
+                <% if current_user.admin? %>
+                  <li class="nav-item">
+                    <%= link_to "ユーザ管理", admin_users_path, class:"nav-link", style: "color: #FFFFFF;" %>
+                  </li>
+                <% end %>
                 <li class="nav-item">
                   <%= link_to "#{@current_user.name}", user_path(@current_user.id), class:"nav-link", style: "color: #FFFFFF;" %>
                 </li>

--- a/app/views/tasks/edit.html.erb
+++ b/app/views/tasks/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="col-6 offset-3">
+  <div class="col-8 offset-2">
 
     <div class="card border-primary rounded-0">
       <div class="card-header bg-transparent border-primary text-center">

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -15,9 +15,9 @@
       <div class="card-header bg-transparent border-primary">
         <div class="row d-flex align-items-center">
           <div class="col-12 text-center">
-            <%= search_form_for @query do |form,class: "form-inline"| %>
+            <%= search_form_for @query do |form| %>
               <%= form.select :status_eq, Task.statuses.map{|key, value| [Task.statuses_i18n[key], value]}, include_blank: 'ステータス' %>
-              <%= form.search_field :name_cont, placeholder: "タスク名" %>
+              <%= form.search_field :name_cont, placeholder: "タスク名", type: 'search_task_name'  %>
               <%= form.submit "検索", class: 'search_btn' %>
             <% end %>
           </div>

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="col-6 offset-3">
+  <div class="col-8 offset-2">
 
     <div class="card border-primary rounded-0">
       <div class="card-header bg-transparent border-primary text-center">

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="col-6 offset-3">
+  <div class="col-8 offset-2">
 
     <div class="card border-primary rounded-0">
       <div class="card-header bg-transparent border-primary">

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -12,7 +12,7 @@
     </div>
     <br>
   <% end %>
-
+ 
   <div class="row d-flex align-items-center form-group">
     <div class="col-4 text-left">
       <strong class="text-primary"><%= t('views.users.name') %></strong>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="col-6 offset-3">
+  <div class="col-8 offset-2">
 
     <div class="card border-primary rounded-0">
       <div class="card-header bg-transparent border-primary text-center">

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="col-6 offset-3">
+  <div class="col-8 offset-2">
 
     <div class="card border-primary rounded-0">
       <div class="card-header bg-transparent border-primary text-center">

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="col-6 offset-3">
+  <div class="col-8 offset-2">
 
     <div class="card border-primary rounded-0">
       <div class="card-header bg-transparent border-primary">
@@ -13,6 +13,22 @@
         </div>
       </div>
       <div class="card-body">
+        <% if current_user.admin == true %>
+          <div class="row">
+            <div class="col-3 text-left">
+              <strong class="text-primary">権限</strong>
+            </div>
+            <div class="col-0.5 text-center">：</div>
+            <div class="col-8.5 text-left">
+              <% if @user.admin == true %>
+                管理者
+              <% else %>
+                一般
+              <% end %>
+            </div>
+          </div>
+          <hr color="#007BFF">
+        <% end %>
         <div class="row">
           <div class="col-3 text-left">
             <strong class="text-primary"><%= t('views.users.name') %></strong>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,10 @@ Rails.application.routes.draw do
 
   root 'users#new'
 
+  namespace :admin do
+    resources :users
+  end
+
   resources :tasks
 
   resources :users

--- a/db/migrate/20190923070420_add_admin_to_users.rb
+++ b/db/migrate/20190923070420_add_admin_to_users.rb
@@ -1,0 +1,5 @@
+class AddAdminToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :admin, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_20_070029) do
+ActiveRecord::Schema.define(version: 2019_09_23_070420) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 2019_09_20_070029) do
     t.string "password_digest", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "admin", default: false, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,3 +1,5 @@
 # conding: utf-8
 
-User.create(name: 'シード1', email: 'seed1@seed.com', password: 'seed111', created_at: DateTime.current, updated_at: DateTime.current)
+User.create(name: '一般ユーザ', email: 'normal@seed.com', password: 'seed111', created_at: DateTime.current, updated_at: DateTime.current, admin: false)
+
+User.create(name: 'adminユーザ', email: 'admin@seed.com', password: 'admin111', created_at: DateTime.current, updated_at: DateTime.current, admin: true)

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,7 +1,8 @@
 FactoryBot.define do
   factory :test_user1, class: User do
     id { 1 }
-    name { 'テストユーザ1' }
+    admin {true}
+    name { 'テストユーザ1(admin)' }
     email { 'test1@example.com' }
     password { 'test111'}
     created_at { DateTime.current }
@@ -10,6 +11,7 @@ FactoryBot.define do
 
   factory :test_user2, class: User do
     id { 2 }
+    admin {false}
     name { 'テストユーザ2' }
     email { 'test2@example.com' }
     password { 'test222'}
@@ -19,9 +21,20 @@ FactoryBot.define do
 
   factory :test_user3, class: User do
     id { 3 }
+    admin {false}
     name { 'テストユーザ3' }
     email { 'test3@example.com' }
     password { 'test333'}
+    created_at { DateTime.current }
+    updated_at { DateTime.current }
+  end
+
+  factory :test_user4, class: User do
+    id { 4 }
+    admin {true}
+    name { 'テストユーザ4' }
+    email { 'test4@example.com' }
+    password { 'test444'}
     created_at { DateTime.current }
     updated_at { DateTime.current }
   end

--- a/spec/features/user.spec.rb
+++ b/spec/features/user.spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.feature "ユーザ管理機能", type: :feature do
+RSpec.feature "ユーザに関する機能", type: :feature do
   scenario "ユーザ新規登録・詳細確認のテスト" do
     # ユーザ登録
     visit new_user_path
@@ -67,5 +67,89 @@ RSpec.feature "ユーザ管理機能", type: :feature do
     expect(page).to have_content 'すでにログインしています。'
   end
 
+  scenario "ユーザ管理(admin)：ユーザ一覧のテスト" do
+    FactoryBot.create(:test_user1)
+    FactoryBot.create(:test_user2)
+    FactoryBot.create(:test_user3)
+    FactoryBot.create(:test_user4)
+    visit new_session_path
+    fill_in 'session_email', with: 'test1@example.com'
+    fill_in 'session_password', with: 'test111'
+    click_on 'ログイン'
 
+    click_on 'ユーザ管理'
+    expect(page).to have_content 'テストユーザ1(admin)'
+    expect(page).to have_content 'テストユーザ2'
+    expect(page).to have_content 'テストユーザ3'
+    expect(page).to have_content 'テストユーザ4'
+  end
+
+  scenario "ユーザ管理(admin)：ユーザ作成・詳細のテスト" do
+    FactoryBot.create(:test_user1)
+    visit new_session_path
+    fill_in 'session_email', with: 'test1@example.com'
+    fill_in 'session_password', with: 'test111'
+    click_on 'ログイン'
+
+    click_on 'ユーザ管理'
+    click_on '新規作成'
+    fill_in 'user_name', with: 'テストユーザ'
+    fill_in 'user_email', with: 'test@example.com'
+    fill_in 'user_password', with: 'test000'
+    fill_in 'user_password_confirmation', with: 'test000'
+
+    click_on '登録する'
+
+    expect(page).to have_content 'テストユーザ'
+  end
+
+  scenario "ユーザ管理(admin)：ユーザ更新のテスト" do
+    FactoryBot.create(:test_user1)
+    FactoryBot.create(:test_user2)
+    visit new_session_path
+    fill_in 'session_email', with: 'test1@example.com'
+    fill_in 'session_password', with: 'test111'
+    click_on 'ログイン'
+
+    click_on 'ユーザ管理'
+    click_on 'テストユーザ2'
+    click_on '編集'
+    fill_in 'user_name', with: '新テストユーザ2！'
+    click_on '更新する'
+
+    expect(page).to have_content '新テストユーザ2！'
+  end
+
+  scenario "ユーザ管理(admin)：ユーザ削除のテスト" do
+    FactoryBot.create(:test_user1)
+    FactoryBot.create(:test_user2)
+    visit new_session_path
+    fill_in 'session_email', with: 'test1@example.com'
+    fill_in 'session_password', with: 'test111'
+    click_on 'ログイン'
+
+    click_on 'ユーザ管理'
+    expect(page).to have_content 'テストユーザ2'
+
+    click_on '×'
+    expect(page).not_to have_content 'テストユーザ2'
+  end
+
+  scenario "ユーザ管理(admin)：一般ユーザはadmin関係のページにアクセス不可になっているかのテスト" do
+    FactoryBot.create(:test_user1)
+    FactoryBot.create(:test_user2)
+    visit new_session_path
+    fill_in 'session_email', with: 'test2@example.com'
+    fill_in 'session_password', with: 'test222'
+    click_on 'ログイン'
+
+    visit admin_users_path
+    expect(page).to have_content '権限がありません。'
+    visit new_admin_user_path
+    expect(page).to have_content '権限がありません。'
+    visit admin_user_path(1)
+    expect(page).to have_content '権限がありません。'
+    visit edit_admin_user_path(1)
+    expect(page).to have_content '権限がありません。'
+  end
 end


### PR DESCRIPTION
#39 
[ステップ21: ユーザの管理画面を実装しよう](https://diver.diveintocode.jp/curriculums/1277#jump-21)

ステップ21、22では管理画面を生成するgem（rails_adminやactive_adminなど）は使用禁止

- [x] 画面上に管理メニューを追加する

- [x] 管理画面にはかならず /admin というURLを先頭につけるようにする

- [x] routes.rb に追加する前に、あらかじめURLやルーティング名（ *_path となる名前）を想定して設計してみる

- [x] 管理画面でユーザ一覧・作成・更新・削除ができるようにする（管理画面のビューはパーシャル化しなくてよい）

- [x] ユーザを削除したら、そのユーザが抱えているタスクも削除する

- [x] ユーザの一覧画面で、ユーザが持っているタスクの数を表示する。その際、N+1問題を回避するための仕組みを取り入れる

- [x] ユーザが作成したタスクの一覧を詳細画面で見られるようにする

- [x] 今回の実装のFeature Specを書く（今回は一覧・作成・詳細・更新・削除のテストを全て書く）