### PR TITLE
【Fixed】step22:ユーザにロールを追加する

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -27,7 +27,7 @@ class Admin::UsersController < ApplicationController
   def create
     @user = User.new(user_params)
     if @user.save
-      redirect_to admin_user_path(@user), notice:  "#{@user.name}さんのアカウントを作成しました。"
+      redirect_to admin_user_path(@user), notice: "#{@user.name}さんのアカウントを作成しました。"
     else
       render :new
     end
@@ -42,14 +42,14 @@ class Admin::UsersController < ApplicationController
   end
 
   def destroy
-    if @user == User.first && @user == User.last
-      redirect_to admin_users_path, notice: "ユーザがゼロになってしまう為、削除できません。"
+    if @user.id == current_user.id
+      redirect_to admin_users_path, notice: "ログイン中のため削除できません。"
     else
-      if @user.admin == true
-        redirect_to admin_users_path, notice: "管理者権限を持つユーザは削除できません。"
-      else
-        @user.destroy
+      @user.destroy
+      if @user.destroyed? == true
         redirect_to admin_users_path, notice: "ユーザを削除しました。"
+      else
+        redirect_to admin_users_path, notice: "管理者をゼロには出来ません。"
       end
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+  before_destroy :last_admin_user?
 
   validates :name,
     length: { in: 1..50 }
@@ -18,4 +19,11 @@ class User < ApplicationRecord
 
   paginates_per 10
 
+  private
+
+  def last_admin_user?
+    if User.where(admin: true).length <= 1 && self.admin == true
+      throw :abort
+    end
+  end
 end

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -58,7 +58,8 @@
                     <td><%= user.created_at.strftime("%Y年%m月%d日") %></td>
                     <td><%= link_to Task.where(user_id: user.id).length, admin_user_url(user), class: 'task_name' %></td>
                     <% if user.admin == true %>
-                      <td colspan="1"></td>
+                      <!-- <td colspan="1"></td> -->
+                      <td><%= link_to '×', admin_user_path(user.id), method: :delete, data: { confirm: "このユーザを削除します。よろしいですか？" } %></td>
                     <% else %>
                       <td><%= link_to '×', admin_user_path(user.id), method: :delete, data: { confirm: "このユーザを削除します。よろしいですか？" } %></td>
                     <% end %>


### PR DESCRIPTION
[ステップ22: ユーザにロールを追加しよう](https://diver.diveintocode.jp/curriculums/1277#jump-22)

- [ ] 管理ユーザと一般ユーザを区別する

- [ ] 管理ユーザだけがユーザ管理画面にアクセスできるようにする

- [ ] 一般ユーザが管理画面にアクセスした場合、専用の例外（エラー）を出してみる
例外を補足して、適切にエラーページを表示する（ステップ23で実施しても構わない）

- [ ] ユーザ管理画面でロールの付与と削除ができるようにする

- [ ] 管理ユーザが1人もいなくならないように削除の制御をする
モデルのコールバックを利用してみる

Gemの使用・不使用は自由（ただし、前述のとおり、管理画面を生成するgemは使わない）
この部分のテストは今回不要。
