### PR TITLE
【Fixed】step24:タスクにラベルを付けられるようにする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,6 +20,8 @@ gem 'kaminari'
 gem 'kaminari-bootstrap'
 gem 'bootstrap'
 gem 'jquery-rails'
+gem 'select2-rails'
+gem "jquery-turbolinks"
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -126,6 +126,9 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jquery-turbolinks (2.1.0)
+      railties (>= 3.1.0)
+      turbolinks
     kaminari (1.1.1)
       activesupport (>= 4.1.0)
       kaminari-actionview (= 1.1.1)
@@ -259,6 +262,8 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
+    select2-rails (4.0.3)
+      thor (~> 0.14)
     selenium-webdriver (3.142.3)
       childprocess (>= 0.5, < 2.0)
       rubyzip (~> 1.2, >= 1.2.2)
@@ -320,6 +325,7 @@ DEPENDENCIES
   factory_bot_rails
   faker
   jquery-rails
+  jquery-turbolinks
   kaminari
   kaminari-bootstrap
   launchy
@@ -333,6 +339,7 @@ DEPENDENCIES
   ransack
   rspec-rails
   sass-rails (~> 5.0)
+  select2-rails
   selenium-webdriver
   spring
   spring-commands-rspec

--- a/app/assets/stylesheets/tasks.scss
+++ b/app/assets/stylesheets/tasks.scss
@@ -81,10 +81,11 @@ top:13px;
 transform: rotate(-45deg);
 }
 
-// 入力フォーム枠
+// 入力フォーム全般
+#session_email, #session_password,
 #task_name, #task_description, #task_deadline_1i, #task_deadline_2i, #task_deadline_3i, #task_status, #task_priority,
 #user_name, ,#user_email, #user_password, #user_password_confirmation, #user_admin,
-#q_status_eq, [type="search_task_name"], [type="search_user_name"], [type="search_user_email"] {
+#q_status_eq, #q_connects_label_id_eq, [type="search_task_name"], [type="search_user_name"], [type="search_user_email"] {
   color: #000000;
   background-color: #FFFFFF;
   background-clip: padding-box;
@@ -93,7 +94,7 @@ transform: rotate(-45deg);
   outline-offset: -1px;
 }
 
-// 終了期限セレクト枠
+// 終了期限セレクトボックス
 #task_deadline_1i, #task_deadline_2i, #task_deadline_3i {
   height: calc(1.5em + 0.75rem + 2px);
   padding: 0.375rem 0.75rem;
@@ -115,7 +116,7 @@ transform: rotate(-45deg);
   width: 20%;
 }
 
-// ステータスセレクト枠、優先順位セレクト枠
+// ステータスセレクトボックス、優先順位セレクトボックス
 #task_status, #task_priority, #user_admin {
     display: block;
     width: 100%;
@@ -127,9 +128,20 @@ transform: rotate(-45deg);
     transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
 }
 
-// ステータスセレクト(検索)枠
+// ラベル検索セレクトボックス
+#q_connects_label_id_eq {
+  width: 15%;
+  height: calc(1.5em + 0.75rem + 2.5px);
+  padding: 0.375rem 0.75rem;
+  font-size: 1rem;
+  font-weight: 400;
+  line-height: 1.5;
+  transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+}
+
+// ステータス検索セレクトボックス
 #q_status_eq {
-  width: 30%;
+  width: 18%;
   height: calc(1.5em + 0.75rem + 2.5px);
   padding: 0.375rem 0.75rem;
   font-size: 1rem;
@@ -140,7 +152,7 @@ transform: rotate(-45deg);
 
 // タスク名検索フォーム
 [type="search_task_name"] {
-  width: 55%;
+  width: 40%;
   height: calc(1.5em + 0.75rem + 2px);
   padding: 0.375rem 0.75rem;
   font-size: 1rem;
@@ -171,7 +183,7 @@ transform: rotate(-45deg);
   transition: border-color 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
 }
 
-// 送信ボタン(検索)枠
+// 送信ボタン(検索)
 .search_btn {
   color: #007BFF;
   background-color: #FFFFFF;

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -48,7 +48,7 @@ class TasksController < ApplicationController
   end
 
   def task_params
-    params.require(:task).permit(:name, :description, :deadline, :status, :priority, :q)
+    params.require(:task).permit(:id, :name, :description, :deadline, :status, :priority, :q, connects_attributes: [:id, :task_id, :label_id], label_ids: [])
   end
 
   def check_task_authority

--- a/app/models/connect.rb
+++ b/app/models/connect.rb
@@ -1,0 +1,4 @@
+class Connect < ApplicationRecord
+  belongs_to :task
+  belongs_to :label
+end

--- a/app/models/connect.rb
+++ b/app/models/connect.rb
@@ -1,4 +1,4 @@
 class Connect < ApplicationRecord
-  belongs_to :task
-  belongs_to :label
+  belongs_to :task, optional: true
+  belongs_to :label, optional: true
 end

--- a/app/models/label.rb
+++ b/app/models/label.rb
@@ -1,0 +1,8 @@
+class Label < ApplicationRecord
+  validates :label,
+    length: { maximum: 50 }
+
+  belongs_to :task
+  has_many :connects, dependent: :destroy
+  has_many :connect_tasks, through: :connects, source: :task
+end

--- a/app/models/label.rb
+++ b/app/models/label.rb
@@ -1,8 +1,6 @@
 class Label < ApplicationRecord
-  validates :label,
-    length: { maximum: 50 }
+  validates :label, length: { maximum: 50 }
 
-  belongs_to :task
   has_many :connects, dependent: :destroy
-  has_many :connect_tasks, through: :connects, source: :task
+  has_many :tasks, through: :connects
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,8 +1,8 @@
 class Task < ApplicationRecord
   validates :name, length: { in: 1..30 }
 
-  enum status: { untouched: 0, in_progress: 1, done: 2, }
-  enum priority: { high: 0, middle: 1, low: 2, }
+  enum status: { untouched: 0, in_progress: 1, done: 2 }
+  enum priority: { high: 0, middle: 1, low: 2 }
 
   scope :sorted, -> { order(created_at: :desc) }
 
@@ -10,6 +10,6 @@ class Task < ApplicationRecord
 
   belongs_to :user
   has_many :connects, dependent: :destroy
-  has_many :connect_labels, through: :connects, source: :label
+  has_many :labels, through: :connects
   accepts_nested_attributes_for :connects, allow_destroy: true
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,5 +1,4 @@
 class Task < ApplicationRecord
-
   validates :name, length: { in: 1..30 }
 
   enum status: { untouched: 0, in_progress: 1, done: 2, }
@@ -10,4 +9,7 @@ class Task < ApplicationRecord
   paginates_per 10
 
   belongs_to :user
+  has_many :connects, dependent: :destroy
+  has_many :connect_labels, through: :connects, source: :label
+  accepts_nested_attributes_for :connects, allow_destroy: true
 end

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -59,6 +59,18 @@
   </div>
   <hr color="#007BFF">
 
+  <div class="row d-flex align-items-center form-group">
+    <div class="col-3 text-left">
+      <strong class="text-primary">ラベル</strong>
+    </div>
+    <div class="col-9 text-left">
+      <% Label.all.each do |label| %>
+        <%= form.check_box :label_ids, { multiple: true, checked: label[:checked], disabled: label[:disabled], include_hidden: false }, label[:id] %>
+        <%= label.label %>
+      <% end %>
+    </div>
+  </div>
+
   <div class="actions text-center">
     <%= form.submit class: "btn btn-outline-primary rounded-0" %>
   </div>

--- a/app/views/tasks/index.html.erb
+++ b/app/views/tasks/index.html.erb
@@ -16,6 +16,7 @@
         <div class="row d-flex align-items-center">
           <div class="col-12 text-center">
             <%= search_form_for @query do |form| %>
+              <%= form.select :connects_label_id_eq, [['仕事', 1], ['勉強', 2], ['交際', 3], ['健康', 4], ['その他', 5]], include_blank: 'ラベル' %>
               <%= form.select :status_eq, Task.statuses.map{|key, value| [Task.statuses_i18n[key], value]}, include_blank: 'ステータス' %>
               <%= form.search_field :name_cont, placeholder: "タスク名", type: 'search_task_name'  %>
               <%= form.submit "検索", class: 'search_btn' %>
@@ -34,9 +35,10 @@
                     <th><%= sort_link(@query, :status, t('views.tasks.status')) %></th>
                     <th><%= sort_link(@query, :name, t('views.tasks.name')) %></th>
                     <th><%= sort_link(@query, :deadline, t('views.tasks.deadline')) %></th>
-                    <th colspan="1"></th>
+                    <th colspan="2"></th>
                   </tr>
                   <tr class="border-bottom border-primary">
+                    <th></th>
                     <th></th>
                     <th></th>
                     <th></th>
@@ -51,6 +53,7 @@
                       <td><%= task.status_i18n %></td>
                       <td><%= link_to task.name, task, class: 'task_name' %></td>
                       <td><%= task.deadline.strftime("%Y年%m月%d日") %></td>
+                      <td><% task.labels.pluck(:label) %></td>
                       <td><%= link_to '×', task, method: :delete, data: { confirm: "このタスクを削除します。よろしいですか？" } %></td>
                     </tr>
                   <% end %>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -65,6 +65,18 @@
         <hr color="#007BFF">
         <div class="row">
           <div class="col-3 text-left">
+            <strong class="text-primary">ラベル</strong>
+          </div>
+          <div class="col-0.5 text-center">：</div>
+          <% @task.labels.pluck(:label).each do |label| %>
+            <div class="text-center">
+              <span class="badge badge-primary mr-1"><%= label %></span>
+            </div>
+          <% end %>
+        </div>
+        <hr color="#007BFF">
+        <div class="row">
+          <div class="col-3 text-left">
             <strong class="text-primary"><%= t('views.tasks.created_at') %></strong>
           </div>
           <div class="col-0.5 text-center">：</div>

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -2,7 +2,7 @@ Rails.application.configure do
 
   config.cache_classes = false
   config.eager_load = false
-  config.consider_all_requests_local = true
+  config.consider_all_requests_local = false #true
 
   if Rails.root.join('tmp', 'caching-dev.txt').exist?
     config.action_controller.perform_caching = true

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -2,7 +2,7 @@ Rails.application.configure do
 
   config.cache_classes = false
   config.eager_load = false
-  config.consider_all_requests_local = false #true
+  config.consider_all_requests_local = true
 
   if Rails.root.join('tmp', 'caching-dev.txt').exist?
     config.action_controller.perform_caching = true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,17 +1,14 @@
 Rails.application.routes.draw do
+  root 'sessions#new'
 
-  root 'users#new'
-
+  resources :sessions
+  resources :users
   namespace :admin do
     resources :users
   end
-
   resources :tasks
-
-  resources :users
-
-  resources :sessions
+  resources :connects
+  resources :labels
 
   # mount LetterOpenerWeb::Engine, at: "/letter_opener" if Rails.env.development?
-
 end

--- a/db/migrate/20190925043507_create_labels.rb
+++ b/db/migrate/20190925043507_create_labels.rb
@@ -1,0 +1,9 @@
+class CreateLabels < ActiveRecord::Migration[5.2]
+  def change
+    create_table :labels do |t|
+      t.string :label
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190925051649_create_connects.rb
+++ b/db/migrate/20190925051649_create_connects.rb
@@ -1,0 +1,10 @@
+class CreateConnects < ActiveRecord::Migration[5.2]
+  def change
+    create_table :connects do |t|
+      t.integer :task_id
+      t.integer :label_id
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,23 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_09_23_070420) do
+ActiveRecord::Schema.define(version: 2019_09_25_051649) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "connects", force: :cascade do |t|
+    t.integer "task_id"
+    t.integer "label_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "labels", force: :cascade do |t|
+    t.string "label"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
 
   create_table "tasks", force: :cascade do |t|
     t.string "name", null: false

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,5 +1,10 @@
 # conding: utf-8
 
 User.create(name: '一般ユーザ', email: 'normal@seed.com', password: 'seed111', created_at: DateTime.current, updated_at: DateTime.current, admin: false)
-
 User.create(name: 'adminユーザ', email: 'admin@seed.com', password: 'admin111', created_at: DateTime.current, updated_at: DateTime.current, admin: true)
+
+Label.create(label: '仕事', created_at: DateTime.current, updated_at: DateTime.current)
+Label.create(label: '勉強', created_at: DateTime.current, updated_at: DateTime.current)
+Label.create(label: '交際', created_at: DateTime.current, updated_at: DateTime.current)
+Label.create(label: '運動', created_at: DateTime.current, updated_at: DateTime.current)
+Label.create(label: 'その他', created_at: DateTime.current, updated_at: DateTime.current)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -1,10 +1,67 @@
 # conding: utf-8
 
-User.create(name: '一般ユーザ', email: 'normal@seed.com', password: 'seed111', created_at: DateTime.current, updated_at: DateTime.current, admin: false)
-User.create(name: 'adminユーザ', email: 'admin@seed.com', password: 'admin111', created_at: DateTime.current, updated_at: DateTime.current, admin: true)
+# 一般ユーザ
+User.create!(
+  [
+    {
+      name: '一般ユーザ1', email: 'test1@seed.com', password: '000000', created_at: DateTime.current, updated_at: DateTime.current, admin: false
+    },
+    {
+      name: '一般ユーザ2', email: 'testl2@seed.com', password: '000000', created_at: DateTime.current, updated_at: DateTime.current, admin: false
+    },
+    {
+      name: '一般ユーザ3', email: 'test3@seed.com', password: '000000', created_at: DateTime.current, updated_at: DateTime.current, admin: false
+    }
+  ]
+)
 
-Label.create(label: '仕事', created_at: DateTime.current, updated_at: DateTime.current)
-Label.create(label: '勉強', created_at: DateTime.current, updated_at: DateTime.current)
-Label.create(label: '交際', created_at: DateTime.current, updated_at: DateTime.current)
-Label.create(label: '運動', created_at: DateTime.current, updated_at: DateTime.current)
-Label.create(label: 'その他', created_at: DateTime.current, updated_at: DateTime.current)
+# 管理者
+User.create!(
+  [
+    {
+      name: '管理者1', email: 'admin1@seed.com', password: '000000', created_at: DateTime.current, updated_at: DateTime.current, admin: true
+    },
+    {
+      name: '管理者2', email: 'admin2@seed.com', password: '000000', created_at: DateTime.current, updated_at: DateTime.current, admin: true
+    },
+    {
+      name: '管理者3', email: 'admin3@seed.com', password: '000000', created_at: DateTime.current, updated_at: DateTime.current, admin: true
+    }
+  ]
+)
+
+# タスク
+Task.create!(
+  [
+    {
+      name: 'タスク1', description: 'タスク1です。', created_at: DateTime.current, updated_at: DateTime.current, deadline: DateTime.current + 1.days, status: 'done', priority: 'high', user_id: 1
+    },
+    {
+      name: 'タスク2', description: 'タスク2です。', created_at: DateTime.current, updated_at: DateTime.current, deadline: DateTime.current + 2.days, status: 'in_progress', priority: 'middle', user_id: 2
+    },
+    {
+      name: 'タスク3', description: 'タスク3です。', created_at: DateTime.current, updated_at: DateTime.current, deadline: DateTime.current + 3.days, status: 'untouched', priority: 'low', user_id: 3
+    }
+  ]
+)
+
+# ラベル
+Label.create!(
+  [
+    {
+      label: '仕事', created_at: DateTime.current, updated_at: DateTime.current
+    },
+    {
+      label: '勉強', created_at: DateTime.current, updated_at: DateTime.current
+    },
+    {
+      label: '交際', created_at: DateTime.current, updated_at: DateTime.current
+    },
+    {
+      label: '健康', created_at: DateTime.current, updated_at: DateTime.current
+    },
+    {
+      label: 'その他', created_at: DateTime.current, updated_at: DateTime.current
+    }
+  ]
+)

--- a/spec/factories/connects.rb
+++ b/spec/factories/connects.rb
@@ -1,6 +1,29 @@
 FactoryBot.define do
-  factory :connect do
-    task_id { 1 }
+  factory :test_connect1, class: Connect do
+    task_id { 14 }
     label_id { 1 }
+    created_at { DateTime.current }
+    updated_at { DateTime.current }
+  end
+
+  factory :test_connect2, class: Connect do
+    task_id { 1 }
+    label_id { 2 }
+    created_at { DateTime.current }
+    updated_at { DateTime.current }
+  end
+
+  factory :test_connect3, class: Connect do
+    task_id { 1 }
+    label_id { 3 }
+    created_at { DateTime.current }
+    updated_at { DateTime.current }
+  end
+
+  factory :test_connect4, class: Connect do
+    task_id { 23 }
+    label_id { 1 }
+    created_at { DateTime.current }
+    updated_at { DateTime.current }
   end
 end

--- a/spec/factories/connects.rb
+++ b/spec/factories/connects.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :connect do
+    task_id { 1 }
+    label_id { 1 }
+  end
+end

--- a/spec/factories/labels.rb
+++ b/spec/factories/labels.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :label do
+    user_id { 1 }
+    task_id { 1 }
+  end
+end

--- a/spec/factories/labels.rb
+++ b/spec/factories/labels.rb
@@ -1,6 +1,36 @@
 FactoryBot.define do
-  factory :label do
-    user_id { 1 }
-    task_id { 1 }
+  factory :test_label1, class: Label do
+    id { 1 }
+    label { '仕事' }
+    created_at { DateTime.current }
+    updated_at { DateTime.current }
+  end
+
+  factory :test_label2, class: Label do
+    id { 2 }
+    label { '勉強' }
+    created_at { DateTime.current }
+    updated_at { DateTime.current }
+  end
+
+  factory :test_label3, class: Label do
+    id { 3 }
+    label { '交際' }
+    created_at { DateTime.current }
+    updated_at { DateTime.current }
+  end
+
+  factory :test_label4, class: Label do
+    id { 4 }
+    label { '健康' }
+    created_at { DateTime.current }
+    updated_at { DateTime.current }
+  end
+
+  factory :test_label5, class: Label do
+    id { 5 }
+    label { 'その他' }
+    created_at { DateTime.current }
+    updated_at { DateTime.current }
   end
 end

--- a/spec/features/task.spec.rb
+++ b/spec/features/task.spec.rb
@@ -1,5 +1,8 @@
 require 'rails_helper'
 
+# puts Task.all.pluck(:id)
+# save_and_open_page
+
 RSpec.feature "タスク管理機能", type: :feature do
   background do
     # テストユーザ
@@ -12,7 +15,19 @@ RSpec.feature "タスク管理機能", type: :feature do
     FactoryBot.create(:test_task2)
     FactoryBot.create(:test_task3)
 
-    # # ログイン処理
+    # テストコネクト（中間テーブル）
+    # FactoryBot.create(:test_connect1)
+    # FactoryBot.create(:test_connect2)
+    # FactoryBot.create(:test_connect3)
+
+    # テストラベル
+    FactoryBot.create(:test_label1)
+    FactoryBot.create(:test_label2)
+    FactoryBot.create(:test_label3)
+    FactoryBot.create(:test_label4)
+    FactoryBot.create(:test_label5)
+
+    # ログイン処理
     visit new_session_path
     ## test_user1でログイン
     fill_in 'session_email', with: 'test1@example.com'
@@ -28,12 +43,9 @@ RSpec.feature "タスク管理機能", type: :feature do
     expect(page).to have_content 'テスト（タスク名）1'
     expect(page).to have_content DateTime.current.strftime("%Y年%m月%d日")
     expect(page).to have_content '×'
-
-    # 他ユーザのタスクが表示されていないかどうか
-    expect(page).not_to have_content 'テスト（タスク名）3'
   end
 
-  scenario "タスク作成のテスト" do
+  scenario "タスク作成のテスト（ラベル込み）" do
     visit new_task_path
 
     fill_in 'task_name', with: '作成テスト(タスク名)'
@@ -43,6 +55,8 @@ RSpec.feature "タスク管理機能", type: :feature do
     select DateTime.current.day, from: 'task_deadline_3i'
     select '未着手', from: 'task_status'
     select '高', from: 'task_priority'
+    check 'task_label_ids_1'
+    check 'task_label_ids_5'
 
     click_on '登録する'
 
@@ -51,6 +65,8 @@ RSpec.feature "タスク管理機能", type: :feature do
     expect(page).to have_content DateTime.current.strftime("%Y年%m月%d日")
     expect(page).to have_content '未着手'
     expect(page).to have_content '高'
+    expect(page).to have_content '仕事'
+    expect(page).to have_content 'その他'
   end
 
   scenario "タスク詳細のテスト" do
@@ -70,8 +86,20 @@ RSpec.feature "タスク管理機能", type: :feature do
     expect(task_last).to have_content "テスト（タスク名）1"
   end
 
-  scenario "タスク検索のテスト" do
-    # ステータス検索
+  scenario "タスク検索のテスト：ラベル検索" do
+    FactoryBot.create(:test_connect1)
+    visit tasks_path
+
+    select '仕事'
+
+    click_on '検索'
+
+    expect(page).to have_content "テスト（タスク名）1"
+    expect(page).not_to have_content "テスト（タスク名）2"
+    expect(page).not_to have_content "テスト（タスク名）3"
+  end
+
+  scenario "タスク検索のテスト：ステータス検索" do
     visit tasks_path
 
     select '完了'
@@ -81,8 +109,9 @@ RSpec.feature "タスク管理機能", type: :feature do
     expect(page).to have_content "テスト（タスク名）1"
     expect(page).not_to have_content "テスト（タスク名）2"
     expect(page).not_to have_content "テスト（タスク名）3"
+  end
 
-    # タスク名検索
+  scenario "タスク検索のテスト：タスク名検索" do
     visit tasks_path
 
     fill_in with: '2'
@@ -92,10 +121,13 @@ RSpec.feature "タスク管理機能", type: :feature do
     expect(page).not_to have_content "テスト（タスク名）1"
     expect(page).to have_content "テスト（タスク名）2"
     expect(page).not_to have_content "テスト（タスク名）3"
+  end
 
-    # ステータス+タスク名検索
+  scenario "タスク検索のテスト：ラベル・ステータス・タスク名組み合わせ検索" do
+    FactoryBot.create(:test_connect4)
     visit tasks_path
 
+    select '仕事'
     select '完了'
     fill_in with: '1'
 
@@ -105,5 +137,4 @@ RSpec.feature "タスク管理機能", type: :feature do
     expect(page).not_to have_content "テスト（タスク名）2"
     expect(page).not_to have_content "テスト（タスク名）3"
   end
-
 end

--- a/spec/models/connect_spec.rb
+++ b/spec/models/connect_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Connect, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/label_spec.rb
+++ b/spec/models/label_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Label, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe User, type: :model do
     expect(user).not_to be_valid
   end
 
-  it "passwordが6文字ちょうどか、それ以上の場合、バリデーションが通らない" do
+  it "passwordが6文字ちょうどか、それ以上の場合、バリデーションが通る" do
     user = User.new(name: 'テストユーザ1', email: 'test1@example.com', password: '123456')
     expect(user).to be_valid
   end


### PR DESCRIPTION
#47 
[ステップ24: タスクにラベルをつけられるようにしよう](https://diver.diveintocode.jp/curriculums/1277#jump-24)

- [x] タスクに複数のラベルをつけられるようにする（ラベルはseedなどのマスタデータで作成する・管理する形でも、管理画面などから作成できる形でも構わない）。

- [x] Taskの詳細画面で、そのTaskに紐づいているLabel一覧を出力できるようにする。
【+α要件】ユーザーが自分でラベルを作成できるようにもする（その場合、ユーザーが作成したラベルはそのユーザーしか使えないように設定する）。
【+α要件】Taskを編集するときに、Taskに紐づいているラベルも一緒に編集（ラベルの付け外し）ができるようにする。

- [x] つけたラベルで検索できるようにする（ラベルは一つだけを選択して、そのラベルが付いているタスクを検索するという形で構わない）。

- [x] 今回の実装のFeature Specを書く。